### PR TITLE
Fix errors caused by upgrading React and react-reconciler

### DIFF
--- a/dist/LayoutNode.d.ts
+++ b/dist/LayoutNode.d.ts
@@ -58,6 +58,7 @@ export declare class LayoutNode implements LayoutParent {
     removeFromParent(): void;
     addVirtualChild(child: LayoutNode): void;
     removeVirtualChild(child: LayoutNode): void;
+    clearChildren(): void;
     setPositionParent(positionParent: LayoutNode | undefined): void;
     setStyle(style: Stash<string>, classNames: string[]): this;
     private applyPseudoSelectors;

--- a/dist/LayoutNode.js
+++ b/dist/LayoutNode.js
@@ -237,18 +237,9 @@ var LayoutNode = /** @class */ (function () {
             LayoutRenderer.unmountLayoutNode(this);
             this.reactFiber = undefined;
         }
-        for (var _i = 0, _a = this.layout.children; _i < _a.length; _i++) {
-            var child = _a[_i];
-            child.node.destructor();
-        }
-        this.layout.children = [];
-        for (var _b = 0, _c = this.virtualChildren; _b < _c.length; _b++) {
-            var vChild = _c[_b];
-            vChild.unmount(true);
-        }
-        this.virtualChildren = [];
-        for (var _d = 0, _e = this.animators; _d < _e.length; _d++) {
-            var animator = _e[_d];
+        this.clearChildren();
+        for (var _i = 0, _a = this.animators; _i < _a.length; _i++) {
+            var animator = _a[_i];
             animator.destructor();
         }
         this.animators = [];
@@ -357,6 +348,18 @@ var LayoutNode = /** @class */ (function () {
         if (idx >= 0) {
             this.virtualChildren.splice(idx, 1);
         }
+    };
+    LayoutNode.prototype.clearChildren = function () {
+        for (var _i = 0, _a = this.layout.children; _i < _a.length; _i++) {
+            var child = _a[_i];
+            child.node.destructor();
+        }
+        this.layout.children = [];
+        for (var _b = 0, _c = this.virtualChildren; _b < _c.length; _b++) {
+            var vChild = _c[_b];
+            vChild.unmount(true);
+        }
+        this.virtualChildren = [];
     };
     LayoutNode.prototype.setPositionParent = function (positionParent) {
         if (this.positionParent) {

--- a/dist/LayoutRenderer.d.ts
+++ b/dist/LayoutRenderer.d.ts
@@ -6,6 +6,5 @@ import { LayoutParent } from './LayoutTypes';
 import { Stash } from 'amper-utils/dist/types';
 import React = require('react');
 export declare function injectIntoDevTools(isProductionMode: boolean): void;
-export declare function flushRendering(): void;
 export declare function renderToLayout(rootNode: LayoutNode | undefined, rootElement: React.ReactNode, parentNode?: LayoutParent, dataProps?: Stash): LayoutNode;
 export declare function unmountLayoutNode(node: LayoutNode): void;

--- a/lib/LayoutNode.ts
+++ b/lib/LayoutNode.ts
@@ -234,15 +234,7 @@ export class LayoutNode implements LayoutParent {
       this.reactFiber = undefined;
     }
 
-    for (const child of this.layout.children) {
-      child.node.destructor();
-    }
-    this.layout.children = [];
-
-    for (const vChild of this.virtualChildren) {
-      vChild.unmount(true);
-    }
-    this.virtualChildren = [];
+    this.clearChildren();
 
     for (const animator of this.animators) {
       animator.destructor();
@@ -368,6 +360,18 @@ export class LayoutNode implements LayoutParent {
     if (idx >= 0) {
       this.virtualChildren.splice(idx, 1);
     }
+  }
+
+  clearChildren() {
+    for (const child of this.layout.children) {
+      child.node.destructor();
+    }
+    this.layout.children = [];
+
+    for (const vChild of this.virtualChildren) {
+      vChild.unmount(true);
+    }
+    this.virtualChildren = [];
   }
 
   setPositionParent(positionParent: LayoutNode|undefined) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/color": "^3.0.0",
     "@types/mocha": "^5.2.5",
     "@types/react": "^18.0.26",
+    "@types/react-reconciler": "^0.28.0",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,7 +81,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react@^18.0.26":
+"@types/react-reconciler@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.0.tgz#513acbed173140e958c909041ca14eb40412077f"
+  integrity sha512-5cjk9ottZAj7eaTsqzPUIlrVbh3hBAO2YaEL1rkjHKB3xNAId7oU8GhzvAX+gfmlfoxTwJnBjPxEHyxkEA1Ffg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^18.0.26":
   version "18.0.26"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.26.tgz#8ad59fc01fef8eaf5c74f4ea392621749f0b7917"
   integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==


### PR DESCRIPTION
The configuration for the newest react-reconciler (for React 18) is very different. Added/removed config as needed, and switched to using the type definitions for that API so future errors will be caught at built time.